### PR TITLE
Add allowedOrigins to cors middleware

### DIFF
--- a/lib/errorHandler.js
+++ b/lib/errorHandler.js
@@ -6,8 +6,15 @@ export const errorHandler = (err, req, res, next) => {
   });
 };
 
+const allowedOrigins = [
+  "https://telegram-chat-app.netlify.app/",
+  "http://localhost:5173",
+];
 export const corsHandler = (req, res, next) => {
-  res.setHeader("Access-Control-Allow-Origin", "*"); // Change * to the specific origin if needed
+  const origin = req.headers.origin;
+  if (allowedOrigins.includes(origin)) {
+    res.setHeader("Access-Control-Allow-Origin", origin);
+  }
   res.setHeader(
     "Access-Control-Allow-Methods",
     "GET, POST, OPTIONS, PUT, PATCH, DELETE"


### PR DESCRIPTION
Removed `"*"` from cors set headers and replace with 

```
const allowedOrigins = [
  "https://telegram-chat-app.netlify.app/",
  "http://localhost:5173",
];